### PR TITLE
Disable description label

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -1,5 +1,5 @@
 name: "jboss-eap-7-tech-preview/eap71-openshift"
-description: "Red Hat JBoss Enterprise Application Platform 7.1 OpenShift container image"
+# description: "Red Hat JBoss Enterprise Application Platform 7.1 OpenShift container image"
 version: "1.0"
 from: "jboss-eap-7/eap71:7.1.0.Beta"
 user: 185


### PR DESCRIPTION
This is a workaround for building in OSBS. The description
label will be populated at the build time with io.k8s.description
label content.