### PR TITLE
Remove duplicate envs

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -20,12 +20,6 @@ envs:
       value: "jee"
     - name: "JBOSS_MODULES_SYSTEM_PKGS"
       value: "org.jboss.logmanager,jdk.nashorn.api"
-    - name: "AB_JOLOKIA_PASSWORD_RANDOM"
-      value: "true"
-    - name: AB_JOLOKIA_AUTH_OPENSHIFT
-      value: "true"
-    - name: AB_JOLOKIA_HTTPS
-      value: "true"
     - name: "DEFAULT_ADMIN_USERNAME"
       value: "eapadmin"
     - name: HTTPS_ENABLE_HTTP2


### PR DESCRIPTION
This pull request removes duplicate environment variables found in the image definition that cause to generate duplicate env variables in the generated Dockerfile. This cleans it up.