### PR TITLE
[CLOUD-1963] update Active MQ RAR for EAP 71

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -151,8 +151,8 @@ artifacts:
       md5: 7c743e35463db5f55f415dd666d705c5
     - path: oauth-20100527.jar
       md5: 91c7c70579f95b7ddee95b2143a49b41
-    - path: activemq-rar-5.11.0.redhat-621084.rar
-      md5: 207e17ac8102c93233fe2764d1fe8499
+    - path: activemq-rar-5.11.0.redhat-630310.rar
+      sha256: ebc2d23c9207fa73cc3908abec2316dce3adbdfbbe88f6f3d7490ec22def747c
     - path: rh-sso-7.1.0-eap7-adapter.zip
       description: "Artifact is available on Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=44831&product=core.service.rhsso&version=7.0&downloadType=distributions"
       sha256: 3d12e310a9b15f79cd46255819a0198acd569921797204c0936772e71dec8d23


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-1963

The existing active-mq-rar artefact is vulnerable to CVE-2016-9878

Existing PR for EAP70 is https://github.com/jboss-container-images/jboss-eap-7-openshift-image/pull/45

It looks like this is still relevant for EAP71, although might be
supersceded by a future JIRA/PR moving the artefact definition out
of the image sources and into cct_module (not raised or implemented
yet.)