### PR TITLE
CLOUD-2365 - MAVEN_ARGS_APPEND to work for S2I builds

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -125,7 +125,6 @@ modules:
           - name: os-eap-logging
           - name: os-eap-probes
           - name: jboss-maven
-          - name: jboss.eap.cd.openshift.maven
           - name: os-eap-db-drivers
           - name: os-eap-sso
           - name: os-eap70-sso


### PR DESCRIPTION
Signed-off-by: Ken Wills <ken@zaptillion.net>

https://issues.jboss.org/browse/CLOUD-2365
https://issues.jboss.org/browse/CLOUD-2206

This removes the temporary maven change and uses maven properties to enable the required maven repo for the needed S2I build templates.