### PR TITLE
CLOUD-2460 - correct image registry prefix

### DIFF
--- a/templates/eap-cd-image-stream.json
+++ b/templates/eap-cd-image-stream.json
@@ -59,7 +59,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "jboss-eap-7-tech-preview/eap-cd-openshift:latest"
+                            "name": "registry.access.redhat.com/jboss-eap-7-tech-preview/eap-cd-openshift:latest"
                         }
                     },
                     {
@@ -77,7 +77,7 @@
                         },
                         "from": {
                             "kind": "DockerImage",
-                            "name": "jboss-eap-7-tech-preview/eap-cd-openshift:12.0"
+                            "name": "registry.access.redhat.com/jboss-eap-7-tech-preview/eap-cd-openshift:12.0"
                         }
                     }
                 ]


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2460
Signed-off-by: Ken Wills <kwills@redhat.com>
