### PR TITLE
Change properties used to define image streams

### DIFF
--- a/tests/arq/pom.xml
+++ b/tests/arq/pom.xml
@@ -24,6 +24,10 @@
         <version.junit>4.12</version.junit>
         <version.org.jboss.as.arquillian.container>7.2.0.Final</version.org.jboss.as.arquillian.container>
         <version.ce-arq>1.3.0.Final</version.ce-arq>
+
+        <image>registry.access.redhat.com/jboss-eap-7/eap71-openshift:1.3</image>
+        <image.stream.version>1.3</image.stream.version>
+        <image.stream.name>jboss-eap71-openshift</image.stream.name>
     </properties>
 
     <dependencyManagement>
@@ -143,6 +147,9 @@
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
                         <arq.extension.openshift.routerHost>${router.hostIP}</arq.extension.openshift.routerHost>
+                        <image.stream.image>${image}</image.stream.image>
+                        <image.stream.name>${image.stream.name}</image.stream.name>
+                        <image.stream.version>${image.stream.version}</image.stream.version>
                         <template.repository>jboss-openshift</template.repository>
                         <template.branch>master</template.branch>
                         <!-- URL to the OpenShift image streams that are officially added to OCP. These image streams are added to every test project run on OpenShift -->

--- a/tests/arq/src/test/java/org/jboss/test/arquillian/ce/common/EapBasicTestBase.java
+++ b/tests/arq/src/test/java/org/jboss/test/arquillian/ce/common/EapBasicTestBase.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
  * @author Marko Luksa
  */
 @OpenShiftResource("${openshift.imageStreams}")
-@OpenShiftDynamicImageStreamResource(name = "${imageStream.eap71.name:jboss-eap71-openshift}", image = "${imageStream.eap71.image:registry.access.redhat.com/jboss-eap-7/eap71-openshift:1.3}", version = "${imageStream.eap71.version:1.3}")
+@OpenShiftDynamicImageStreamResource(name = "${image.stream.name}", image = "${image.stream.image}", version = "${image.stream.version}")
 public class EapBasicTestBase {
 
     private Logger log = Logger.getLogger(getClass().getName());

--- a/tests/arq/src/test/java/org/jboss/test/arquillian/ce/common/EapClusteringTestBase.java
+++ b/tests/arq/src/test/java/org/jboss/test/arquillian/ce/common/EapClusteringTestBase.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue;
  * @author Jonh Wendell
  */
 @OpenShiftResource("${openshift.imageStreams}")
-@OpenShiftDynamicImageStreamResource(name = "${imageStream.eap71.name:jboss-eap71-openshift}", image = "${imageStream.eap71.image:registry.access.redhat.com/jboss-eap-7/eap71-openshift:1.3}", version = "${imageStream.eap71.version:1.3}")
+@OpenShiftDynamicImageStreamResource(name = "${image.stream.name}", image = "${image.stream.image}", version = "${image.stream.version}")
 public class EapClusteringTestBase {
     protected final Logger log = Logger.getLogger(getClass().getName());
     private final HttpClientExecuteOptions execOptions = new HttpClientExecuteOptions.Builder().tries(3)

--- a/tests/arq/src/test/java/org/jboss/test/arquillian/ce/common/EapDbTestBase.java
+++ b/tests/arq/src/test/java/org/jboss/test/arquillian/ce/common/EapDbTestBase.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  * @author Marko Luksa
  */
 @OpenShiftResource("${openshift.imageStreams}")
-@OpenShiftDynamicImageStreamResource(name = "${imageStream.eap71.name:jboss-eap71-openshift}", image = "${imageStream.eap71.image:registry.access.redhat.com/jboss-eap-7/eap71-openshift:1.3}", version = "${imageStream.eap71.version:1.3}")
+@OpenShiftDynamicImageStreamResource(name = "${image.stream.name}", image = "${image.stream.image}", version = "${image.stream.version}")
 public abstract class EapDbTestBase {
     @RouteURL("eap-app")
     private URL url;

--- a/tests/arq/src/test/java/org/jboss/test/arquillian/ce/common/EapPersistentTestBase.java
+++ b/tests/arq/src/test/java/org/jboss/test/arquillian/ce/common/EapPersistentTestBase.java
@@ -17,7 +17,7 @@ import org.junit.Test;
  * @author Marko Luksa
  */
 @OpenShiftResource("${openshift.imageStreams}")
-@OpenShiftDynamicImageStreamResource(name = "${imageStream.eap71.name:jboss-eap71-openshift}", image = "${imageStream.eap71.image:registry.access.redhat.com/jboss-eap-7/eap71-openshift:1.3}", version = "${imageStream.eap71.version:1.3}")
+@OpenShiftDynamicImageStreamResource(name = "${image.stream.name}", image = "${image.stream.image}", version = "${image.stream.version}")
 public abstract class EapPersistentTestBase {
 
     private final static Logger log = Logger.getLogger(EapPersistentTestBase.class.getName());


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2732

This will make it easier to run on CI by specifying the image to test like this `-Dimage=registry.corp/jboss-eap-7/eap71-openshift:dev`.