### PR TITLE
Eap70 dev sync with cctmodule master

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -227,7 +227,7 @@ packages:
           - python-enum34
           - PyYAML
 artifacts:
-    - url: https://maven.repository.redhat.com/ga/org/jolokia/jolokia-jvm/1.3.6.redhat-1/jolokia-jvm-1.3.6.redhat-1-agent.jar
+    - url: https://maven.repository.redhat.com/ga/org/jolokia/jolokia-jvm/1.5.0.redhat-1/jolokia-jvm-1.5.0.redhat-1-agent.jar
       md5: 75e5b5ba0b804cd9def9f20a70af649f
     - path: javax.json-1.0.4.jar
       md5: 569870f975deeeb6691fcb9bc02a9555
@@ -235,7 +235,7 @@ artifacts:
       md5: 7c743e35463db5f55f415dd666d705c5
     - path: oauth-20100527.jar
       md5: 91c7c70579f95b7ddee95b2143a49b41
-    - url: https://maven.repository.redhat.com/ga/org/apache/activemq/activemq-rar/5.11.0.redhat-630262/activemq-rar-5.11.0.redhat-630262.rar
+    - url: https://maven.repository.redhat.com/ga/org/apache/activemq/activemq-rar/5.11.0.redhat-630347/activemq-rar-5.11.0.redhat-630347.rar
       md5: d0c70b9b2da1f02473d52f59d1d14b0b
     - path: rh-sso-7.1.0-eap7-adapter.zip
       description: "Artifact is available on Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=44831&product=core.service.rhsso&version=7.0&downloadType=distributions"


### PR DESCRIPTION
I'm not able to build eap70-dev branch against the master of cct_module. I think there is need to be fixed versions of the libraries. Then the build passes.

Is that correct procedure? @luck3y @rcernich 