### PR TITLE
[CLOUD-2838] Use the jboss.eap.cd14.openshift module to provide stand…

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -43,6 +43,7 @@ modules:
           - name: os-java-jolokia
           - name: jboss.eap.cd.jolokia
           - name: os-eap7-openshift
+          - name: jboss.eap.cd14.openshift
           - name: jboss.eap.cd.openshift.modules
           - name: os-eap7-ping
           - name: os-java-run


### PR DESCRIPTION
…alone-openshift.xml

Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>

https://issues.jboss.org/browse/CLOUD-2838

This requires https://github.com/jboss-container-images/jboss-eap-modules/pull/22 to be merged first.