### PR TITLE
 [CLOUD-2729] Integrate the jboss.eap.config.mp-config module

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -43,6 +43,7 @@ modules:
           - name: os-java-jolokia
           - name: jboss.eap.cd.jolokia
           - name: os-eap7-openshift
+          - name: jboss.eap.cd14.openshift
           - name: jboss.eap.cd.openshift.modules
           - name: os-eap7-ping
           - name: os-java-run

--- a/image.yaml
+++ b/image.yaml
@@ -51,6 +51,7 @@ modules:
           - name: os-eap7-launch
           - name: jboss.eap.cd.openshift.launch
           - name: jboss.eap.cd.logging
+          - name: jboss.eap.config.mp-config
           - name: os-eap-probes
           - name: jboss-maven
           - name: os-eap-db-drivers


### PR DESCRIPTION
Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>

https://issues.jboss.org/browse/CLOUD-2729

Also brings in the commit from #135 as this requires that.

Requires https://github.com/jboss-container-images/jboss-eap-modules/pull/26 to be merged first.