### PR TITLE
[CLOUD-2812] Update to registry.access.redhat.com -> registry.redhat.io

### DIFF
--- a/templates/eap-cd-image-stream.json
+++ b/templates/eap-cd-image-stream.json
@@ -59,6 +59,9 @@
                             "version": "14",
                             "openshift.io/display-name": "JBoss EAP continuous delivery (Tech Preview)"
                         },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
                         "from": {
                             "kind": "ImageStreamTag",
                             "name": "14.0"
@@ -78,6 +81,9 @@
                             "version": "13",
                             "openshift.io/display-name": "JBoss EAP continuous delivery (Tech Preview)"
                         },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
                         "from": {
                             "kind": "ImageStreamTag",
                             "name": "13.0"
@@ -96,6 +102,9 @@
                             "sampleRef": "openshift",
                             "version": "12",
                             "openshift.io/display-name": "JBoss EAP continuous delivery (Tech Preview)"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "ImageStreamTag",
@@ -157,6 +166,9 @@
                             "sampleRef": "openshift",
                             "version": "14.0",
                             "openshift.io/display-name": "JBoss EAP continuous delivery (Tech Preview)"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
                         },
                         "from": {
                             "kind": "DockerImage",


### PR DESCRIPTION
This is an additional change that also switches the imagestream tags to use referencePolicy local.

https://issues.jboss.org/browse/CLOUD-2812
Signed-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
