### PR TITLE
CLOUD-2788 / CLOUD-2546 - support for upstream KUBE_PING and DNS_PING

### DIFF
--- a/docs/templates/eap-cd-amq-persistent-s2i.adoc
+++ b/docs/templates/eap-cd-amq-persistent-s2i.adoc
@@ -292,4 +292,90 @@ more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-amq-s2i.adoc
+++ b/docs/templates/eap-cd-amq-s2i.adoc
@@ -272,4 +272,90 @@ for more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-basic-s2i.adoc
+++ b/docs/templates/eap-cd-basic-s2i.adoc
@@ -194,4 +194,90 @@ for more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-https-s2i.adoc
+++ b/docs/templates/eap-cd-https-s2i.adoc
@@ -227,4 +227,90 @@ for more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-mongodb-persistent-s2i.adoc
+++ b/docs/templates/eap-cd-mongodb-persistent-s2i.adoc
@@ -285,4 +285,90 @@ more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-mongodb-s2i.adoc
+++ b/docs/templates/eap-cd-mongodb-s2i.adoc
@@ -270,4 +270,90 @@ for more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-mysql-persistent-s2i.adoc
+++ b/docs/templates/eap-cd-mysql-persistent-s2i.adoc
@@ -289,4 +289,90 @@ more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-mysql-s2i.adoc
+++ b/docs/templates/eap-cd-mysql-s2i.adoc
@@ -274,4 +274,90 @@ for more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-postgresql-persistent-s2i.adoc
+++ b/docs/templates/eap-cd-postgresql-persistent-s2i.adoc
@@ -284,4 +284,90 @@ more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-postgresql-s2i.adoc
+++ b/docs/templates/eap-cd-postgresql-s2i.adoc
@@ -269,4 +269,90 @@ for more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-sso-s2i.adoc
+++ b/docs/templates/eap-cd-sso-s2i.adoc
@@ -266,4 +266,90 @@ for more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-starter-s2i.adoc
+++ b/docs/templates/eap-cd-starter-s2i.adoc
@@ -179,4 +179,90 @@ for more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-third-party-db-s2i.adoc
+++ b/docs/templates/eap-cd-third-party-db-s2i.adoc
@@ -232,4 +232,90 @@ for more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/docs/templates/eap-cd-tx-recovery-s2i.adoc
+++ b/docs/templates/eap-cd-tx-recovery-s2i.adoc
@@ -311,4 +311,90 @@ more information.
 
 
 
+[[clustering]]
+==== Clustering
+
+Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
+
+The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
+
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
+
+. The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
+  name of the ping service for the cluster (see table above).  If not set, the
+  server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_DNS_PING_SERVICE_PORT` environment variables should be set to
+  the port number on which the ping service is exposed (see table above).  The
+  `DNS_PING` protocol will attempt to discern the port from the SRV records, if
+  it can, otherwise it will default to 8888.
+. A ping service which exposes the ping port must be defined.  This service
+  should be "headless" (ClusterIP=None) and must have the following:
+.. The port must be named for port discovery to work.
+.. It must be annotated with `service.alpha.kubernetes.io/tolerate-unready-endpoints`
+   set to `"true"`.  Omitting this annotation will result in each node forming
+   their own "cluster of one" during startup, then merging their cluster into
+   the other nodes' clusters after startup (as the other nodes are not detected
+   until after they have started).
+
+.Example ping service for use with DNS_PING
+[source,yaml]
+----
+kind: Service
+apiVersion: v1
+spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+        deploymentConfig: eap-app
+metadata:
+    name: eap-app-ping
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+----
+
+For `KUBE_PING` to work, the following steps must be taken:
+
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
+. The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
+. Authorization must be granted to the service account the pod is running under to be
+  allowed to access Kubernetes' REST api. This is done on the command line.
+
+.Policy commands
+====
+Using the default service account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:default -n myproject
+....
+Using the eap-service-account in the myproject namespace:
+....
+oc policy add-role-to-user view system:serviceaccount:myproject:eap-service-account -n myproject
+....
+====
+
 

--- a/gen_template_docs.py
+++ b/gen_template_docs.py
@@ -148,9 +148,7 @@ def createTemplate(data, path):
                     if len(secretName) > 0:
  	                  tdata['objects'][0]['secrets'] = [{ "secretName": secretName[0], "secretFile": secretName[0] + ".json" }]
 		    
-        # currently the clustering section applies only to EAP templates
-        if re.match('^eap', path):
-            tdata['objects'][0]['clustering'] = [{}]
+    tdata['objects'][0]['clustering'] = [{}]
 
     return templater.render(tdata)
 

--- a/template.adoc.in
+++ b/template.adoc.in
@@ -183,17 +183,22 @@ to be installed for the application to run.
 ==== Clustering
 
 Clustering in OpenShift EAP is achieved through one of two discovery mechanisms:
-Kubernetes or DNS. This is done by configuring the JGroups protocol stack in
-standalone-openshift.xml with either the `<openshift.KUBE_PING/>` or `<openshift.DNS_PING/>`
-elements. The templates are configured to use `DNS_PING`, however `KUBE_PING`is
-the default used by the image.
+KUBE_PING or DNS_PING. This is done by configuring the JGroups protocol stack in
+standalone-openshift.xml with any of the following mechanisms:
+`<kubernetes.KUBE_PING>`, `<dns.DNS_PING>`, `<openshift.KUBE_PING/>` or
+`<openshift.DNS_PING/>`. The templates are configured to use `DNS_PING`, however
+`KUBE_PING` is the default used by the image.
 
 The discovery mechanism used is specified by the `JGROUPS_PING_PROTOCOL` environment
-variable which can be set to either `openshift.DNS_PING` or `openshift.KUBE_PING`.
-`openshift.KUBE_PING` is the default used by the image if no value is specified
-for `JGROUPS_PING_PROTOCOL`.
+variable which can be set to `openshift.DNS_PING`, `kubernetes.KUBE_PING`,
+`dns.DNS_PING` or `openshift.KUBE_PING`. `KUBE_PING` is the default used
+by the image if no value is specified for `JGROUPS_PING_PROTOCOL` for compatibility
+with previous releases.
 
-For DNS_PING to work, the following steps must be taken:
+WARN: `openshift.DNS_PING` and `openshift.KUBE_PING` are deprecated and may be removed
+in a future release.
+
+For `DNS_PING` to work, the following steps must be taken:
 
 . The `OPENSHIFT_DNS_PING_SERVICE_NAME` environment variable must be set to the
   name of the ping service for the cluster (see table above).  If not set, the
@@ -232,10 +237,19 @@ metadata:
 
 For `KUBE_PING` to work, the following steps must be taken:
 
+For `kubernetes.KUBE_PING`:
+. The `KUBERNETES_NAMESPACE` environment variable must be set (see table above).
+  If not set, the server will act as if it is a single-node cluster (a "cluster of one").
+. The `KUBERNETES_LABELS` environment variables should be set (see table above).
+  If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For legacy `openshift.KUBE_PING`
 . The `OPENSHIFT_KUBE_PING_NAMESPACE` environment variable must be set (see table above).
   If not set, the server will act as if it is a single-node cluster (a "cluster of one").
 . The `OPENSHIFT_KUBE_PING_LABELS` environment variables should be set (see table above).
   If not set, pods outside of your application (albeit in your namespace) will try to join.
+
+For both implementations:
 . Authorization must be granted to the service account the pod is running under to be
   allowed to access Kubernetes' REST api. This is done on the command line.
 


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2788
https://issues.jboss.org/browse/CLOUD-2546

This fixes the documentation generation to include the clustering parts.

Signed-off-by: Ken Wills kwills@redhat.com

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
