### PR TITLE
[CLOUD-2728] Integrate the jboss.eap.config.tracing module

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -54,6 +54,7 @@ modules:
           - name: jboss.eap.config.mp-config
           - name: jboss.eap.config.jgroups
           - name: jboss.eap.config.elytron
+          - name: jboss.eap.config.tracing
           - name: os-eap-probes
           - name: jboss-maven
           - name: os-eap-db-drivers


### PR DESCRIPTION
Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>

https://issues.jboss.org/browse/CLOUD-2728

Requires https://github.com/jboss-container-images/jboss-eap-modules/pull/31