### PR TITLE
[CLOUD-2786] Install the legacy activemq-rar.rar in case the app want…

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -46,6 +46,7 @@ modules:
           - name: jboss.eap.cd14.openshift
           - name: jboss.eap.cd.openshift.modules
           - name: os-eap7-ping
+          - name: os-eap-activemq-rar
           - name: os-java-run
           - name: os-eap-launch
           - name: os-eap7-launch


### PR DESCRIPTION
…s it

https://issues.jboss.org/browse/CLOUD-2786

Needs https://github.com/jboss-container-images/jboss-eap-modules/pull/32 as well.