### PR TITLE
[CLOUD-2995] Base on RHEL7 instead of openjdk + eap standalone image

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -9,6 +9,10 @@ modules:
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
                   ref: sprint-20
+          - name: jboss-eap-7-image
+            git:
+                  url: https://github.com/jboss-container-images/jboss-eap-7-image.git
+                  ref: eap72-cp
 osbs:
       repository:
             name: containers/jboss-eap-7

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -10,6 +10,10 @@ modules:
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
                   ref: master
+          - name: jboss-eap-7-image
+            git:
+                  url: https://github.com/jboss-container-images/jboss-eap-7-image.git
+                  ref: eap72-dev
 osbs:
       repository:
             name: containers/jboss-eap-7

--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "jboss-eap-7/eap72-openshift"
 description: "Red Hat JBoss Enterprise Application Platform 7.2 OpenShift container image"
 version: "1.0"
-from: "jboss-eap-7/eap72:7.2.0"
+from: "rhel7:7-released"
 labels:
     - name: "com.redhat.component"
       value: "jboss-eap-7-eap72-openshift-container"
@@ -35,7 +35,14 @@ modules:
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
                   ref: master
+          - name: jboss-eap-7-image
+            git:
+                  url: https://github.com/jboss-container-images/jboss-eap-7-image.git
+                  ref: eap72
       install:
+          - name: jboss.container.openjdk.jdk
+            version: "8"
+          - name: eap-7.2-latest
           - name: dynamic-resources
           - name: s2i-common
           - name: java-alternatives
@@ -71,6 +78,8 @@ modules:
           - name: os-logging
 packages:
       repositories:
+          - name: base
+            id: rhel-7-server-rpms
           - jboss-os
       install:
           - python-requests

--- a/rel-overrides.yaml
+++ b/rel-overrides.yaml
@@ -9,6 +9,10 @@ modules:
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
                   ref: sprint-20
+          - name: jboss-eap-7-image
+            git:
+                  url: https://github.com/jboss-container-images/jboss-eap-7-image.git
+                  ref: eap72
 osbs:
       repository:
             name: containers/jboss-eap-7


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2995

This is built on top of #165 as I want the change of the 7.2 image structure to be after the basic change from 7.2 Beta to GA.