### PR TITLE
[CLOUD-2993] - Move base layer of EAP 7.1 image from jboss-openjdk to rhel7

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -6,6 +6,11 @@ modules:
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
                   ref: sprint-18
+          - name: jboss-eap-7-image
+            git:
+￼                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
+￼                   ref: eap71-cp
+
 osbs:
       repository:
             name: containers/jboss-eap-7

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -10,6 +10,10 @@ modules:
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
                   ref: master
+          - name: jboss-eap-7-image
+            git:
+￼                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
+￼                   ref: eap71-dev
 
 osbs:
       repository:

--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "jboss-eap-7/eap71-openshift"
 description: "Red Hat JBoss Enterprise Application Platform 7.1 OpenShift container image"
 version: "1.4"
-from: "jboss-eap-7/eap71:latest"
+from: "rhel7:7-released"
 labels:
     - name: "com.redhat.component"
       value: "jboss-eap-7-eap71-openshift-container"
@@ -35,7 +35,14 @@ modules:
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
                   ref: master
+          - name: jboss-eap-7-image
+            git:
+                  url: https://github.com/jboss-container-images/jboss-eap-7-image.git
+                  ref: eap71
       install:
+          - name: jboss.container.openjdk.jdk
+            version: "8"
+          - name: eap-7.1-latest
           - name: dynamic-resources
           - name: s2i-common
           - name: java-alternatives
@@ -69,6 +76,8 @@ modules:
           - name: os-logging
 packages:
       repositories:
+          - name: base
+            id: rhel-7-server-rpms
           - jboss-os
       install:
           - python-requests

--- a/rel-overrides.yaml
+++ b/rel-overrides.yaml
@@ -6,6 +6,11 @@ modules:
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
                   ref: sprint-18
+          - name: jboss-eap-7-image
+            git:
+￼                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
+￼                   ref: eap71
+
 osbs:
       repository:
             name: containers/jboss-eap-7


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2993
Signed-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
