### PR TITLE
CLOUD-2720 - amq-s2i template missing MQ_ROLE param

### DIFF
--- a/templates/eap72-amq-s2i.json
+++ b/templates/eap72-amq-s2i.json
@@ -143,6 +143,12 @@
             "required": false
         },
         {
+            "displayName": "AMQ Role",
+            "description": "AMQ Role for authenticated user",
+            "name": "MQ_ROLE",
+            "value": "admin"
+        },
+        {
             "displayName": "AMQ Mesh Discovery Type",
             "description": "The discovery agent type to use for discovering mesh endpoints.  'dns' will use OpenShift's DNS service to resolve endpoints.  'kube' will use Kubernetes REST API to resolve service endpoints.  If using 'kube' the service account for the pod must have the 'view' role, which can be added via 'oc policy add-role-to-user view system:serviceaccount:<namespace>:default' where <namespace> is the project namespace.",
             "name": "AMQ_MESH_DISCOVERY_TYPE",
@@ -626,6 +632,10 @@
                                     {
                                         "name": "MQ_PASSWORD",
                                         "value": "${MQ_PASSWORD}"
+                                    },
+                                    {
+                                        "name": "MQ_ROLE",
+                                        "value": "${MQ_ROLE}"
                                     },
                                     {
                                         "name": "MQ_PROTOCOL",


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2720
Signed-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
