### PR TITLE
[CLOUD-3081] eap-cd-tx-recovery-postgresql-s2i template build config to be incremental

### DIFF
--- a/templates/eap-cd-tx-recovery-postgresql-s2i.json
+++ b/templates/eap-cd-tx-recovery-postgresql-s2i.json
@@ -478,6 +478,7 @@
                             }
                         ],
                         "forcePull": true,
+                        "incremental": true,
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3081

the other templates (even the txn recovery) uses the BuildConfig to be set with `"incremental": true`. It's reasonable to follow the https://issues.jboss.org/browse/CLOUD-2889 and set up that for the postgresql recovery template as well.