### PR TITLE
[CLOUD-3141] txnrecovery python3 eap cd dev: eap-cd-dev

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -79,6 +79,8 @@ modules:
           - name: openshift-passwd
           - name: os-logging
           - name: jboss.container.eap.prometheus.config
+          - name: os-eap-txnrecovery.run
+            version: 'python2'
 packages:
       content_sets_file: content_sets.yml
       install:


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3141

txnrecovery module moved to versioning python version to be used and needs to be referred in the `image.yaml`