### PR TITLE
[CLOUD-3141] adding dependency to os-eap-txrecovery:python2 module : eap71-dev

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -76,6 +76,8 @@ modules:
           - name: os-logging
           - name: jboss.container.eap.prometheus.config
             version: '7.1'
+          - name: os-eap-txnrecovery.run
+            version: 'python2'
 packages:
       repositories:
           - name: base


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3141

txnrecovery module moved to versioning python version to be used and needs to be referred in the image.yaml