### PR TITLE
[CLOUD-3121] - EAP72] JDK 11 Image Stream for EAP 7.2 on OS

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -45,7 +45,6 @@ modules:
           - name: eap-7.2-latest
           - name: dynamic-resources
           - name: s2i-common
-          - name: java-alternatives
           - name: os-eap-s2i
           - name: os-java-jolokia
           - name: jboss.eap.cd.jolokia


### PR DESCRIPTION
 - Drop usage of the JDK8 java-alternatives module.

https://issues.jboss.org/browse/CLOUD-3121
SIgned-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
