### PR TITLE
Revert " Update cp-overrides to EAP 7.2.1 CR2"

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -5,15 +5,15 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: sprint-28
+                  ref: sprint-27
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: sprint-31
+                  ref: EAP_720
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP_721_CR2
+                  ref: EAP_720
 osbs:
       repository:
             name: containers/jboss-eap-7


### PR DESCRIPTION
https://github.com/jboss-container-images/jboss-eap-7-openshift-image/pull/228
Reverts jboss-container-images/jboss-eap-7-openshift-image#227 to correct missing jira issue.

https://issues.jboss.org/browse/CLOUD-3160
Signed-off-by: Ken Wills <kwills@redhat.com>