### PR TITLE
[CLOUD-3243] Update cp-overrides to EAP 7.2.2 CR1

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -13,7 +13,7 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP_721_CR3
+                  ref: EAP_722_CR1
 osbs:
       repository:
             name: containers/jboss-eap-7


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3243
Upstream PR: https://github.com/jboss-container-images/jboss-eap-7-openshift-image/pull/240
Signed-off-by: Roberto Oliveira rguimara@redhat.com