### PR TITLE
[CLOUD-3242] Update jboss-eap-modules in cp-overrides to EAP 7.2.2 CR1

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -9,7 +9,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: sprint-31
+                  ref: EAP_722_CR1
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3242
Signed-off-by: Roberto Oliveira rguimara@redhat.com