### PR TITLE
[CLOUD-3300] Fixing wrong RHSSO and EAP ImageStreamTag name for Git and Source strategy in eap72-openjdk11-sso-s2i template

### DIFF
--- a/templates/eap72-openjdk11-sso-s2i.json
+++ b/templates/eap72-openjdk11-sso-s2i.json
@@ -491,7 +491,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "${EAP_IMAGE_NAME}"
+                                "name": "redhat-sso73-openshift:1.0"
                             },
                             "paths": [
                                 {
@@ -510,7 +510,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap72-openshift:1.0"
+                            "name": "${EAP_IMAGE_NAME}"
                         },
                         "env": [
                             {


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3300

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
