### PR TITLE
[CLOUD-3249] Allow kubernetes to control probe retries; avoid probes …

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -30,6 +30,8 @@ toc::[levels=1]
 * link:./templates/eap72-starter-s2i.adoc[eap72-starter-s2i]
 * link:./templates/eap72-third-party-db-s2i.adoc[eap72-third-party-db-s2i]
 * link:./templates/eap72-tx-recovery-s2i.adoc[eap72-tx-recovery-s2i]
+* link:./templates/t.adoc[t]
+* link:./templates/template-names.adoc[template-names]
 
 ////
   the source for the release notes part of this page is in the file

--- a/image.yaml
+++ b/image.yaml
@@ -65,6 +65,7 @@ modules:
           - name: jboss.eap.config.elytron
           - name: jboss.eap.config.tracing
           - name: os-eap-probes
+            version: "1.0"
           - name: jboss-maven
           - name: os-eap-db-drivers
           - name: os-eap-sso

--- a/templates/eap72-amq-persistent-s2i.json
+++ b/templates/eap72-amq-persistent-s2i.json
@@ -604,9 +604,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-amq-s2i.json
+++ b/templates/eap72-amq-s2i.json
@@ -590,9 +590,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-basic-s2i.json
+++ b/templates/eap72-basic-s2i.json
@@ -364,9 +364,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-https-s2i.json
+++ b/templates/eap72-https-s2i.json
@@ -489,9 +489,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-mongodb-persistent-s2i.json
+++ b/templates/eap72-mongodb-persistent-s2i.json
@@ -603,9 +603,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-mongodb-s2i.json
+++ b/templates/eap72-mongodb-s2i.json
@@ -596,9 +596,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-mysql-persistent-s2i.json
+++ b/templates/eap72-mysql-persistent-s2i.json
@@ -607,9 +607,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-mysql-s2i.json
+++ b/templates/eap72-mysql-s2i.json
@@ -600,9 +600,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-postgresql-persistent-s2i.json
+++ b/templates/eap72-postgresql-persistent-s2i.json
@@ -589,9 +589,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-postgresql-s2i.json
+++ b/templates/eap72-postgresql-s2i.json
@@ -582,9 +582,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-sso-s2i.json
+++ b/templates/eap72-sso-s2i.json
@@ -646,9 +646,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-starter-s2i.json
+++ b/templates/eap72-starter-s2i.json
@@ -307,9 +307,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-third-party-db-s2i.json
+++ b/templates/eap72-third-party-db-s2i.json
@@ -551,9 +551,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-tx-recovery-s2i.json
+++ b/templates/eap72-tx-recovery-s2i.json
@@ -527,9 +527,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "volumeMounts": [
                                     {


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3249
Upstream PR: https://github.com/jboss-container-images/jboss-eap-7-openshift-image/pull/246
Signed-off-by: Roberto Oliveira rguimara@redhat.com