### PR TITLE
[CLOUD-3250] Allow kubernetes to control probe retries; avoid probes …

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -26,6 +26,8 @@ toc::[levels=1]
 * link:./templates/eap72-openjdk11-tx-recovery-s2i.adoc[eap72-openjdk11-tx-recovery-s2i]
 * link:./templates/t.adoc[t]
 * link:./templates/template-names.adoc[template-names]
+* link:./templates/t.adoc[t]
+* link:./templates/template-names.adoc[template-names]
 
 ////
   the source for the release notes part of this page is in the file

--- a/templates/eap72-openjdk11-amq-persistent-s2i.json
+++ b/templates/eap72-openjdk11-amq-persistent-s2i.json
@@ -611,9 +611,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-openjdk11-amq-s2i.json
+++ b/templates/eap72-openjdk11-amq-s2i.json
@@ -597,9 +597,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-openjdk11-basic-s2i.json
+++ b/templates/eap72-openjdk11-basic-s2i.json
@@ -371,9 +371,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-openjdk11-https-s2i.json
+++ b/templates/eap72-openjdk11-https-s2i.json
@@ -496,9 +496,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-openjdk11-sso-s2i.json
+++ b/templates/eap72-openjdk11-sso-s2i.json
@@ -653,9 +653,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-openjdk11-starter-s2i.json
+++ b/templates/eap72-openjdk11-starter-s2i.json
@@ -314,9 +314,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-openjdk11-third-party-db-s2i.json
+++ b/templates/eap72-openjdk11-third-party-db-s2i.json
@@ -558,9 +558,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "ports": [
                                     {

--- a/templates/eap72-openjdk11-tx-recovery-s2i.json
+++ b/templates/eap72-openjdk11-tx-recovery-s2i.json
@@ -534,9 +534,10 @@
                                         "command": [
                                             "/bin/bash",
                                             "-c",
-                                            "/opt/eap/bin/readinessProbe.sh"
+                                            "/opt/eap/bin/readinessProbe.sh false"
                                         ]
-                                    }
+                                    },
+                                    "initialDelaySeconds": 10
                                 },
                                 "volumeMounts": [
                                     {


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3250
Upstream PR: https://github.com/jboss-container-images/jboss-eap-7-openshift-image/pull/246
Signed-off-by: Roberto Oliveira rguimara@redhat.com