### PR TITLE
[CLOUD-3302] update overrides files to EAP 7.2.3 CR2

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -5,15 +5,15 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module
-        ref: sprint-35
+        ref: 0.35.1
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_722_OPENJDK11_CR1
+        ref: EAP_723_OPENJDK11_CR2
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_722_CR1
+        ref: EAP_723_CR2
 osbs:
   repository:
     name: containers/jboss-eap-7

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -5,15 +5,15 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module
-                  ref: sprint-35
+                  ref: 0.35.1
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: EAP_722_OPENJDK11_CR1
+                  ref: EAP_723_OPENJDK11_CR2
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP_722_CR1
+                  ref: EAP_723_CR2
 osbs:
       repository:
             name: containers/jboss-eap-7

--- a/rel-overrides.yaml
+++ b/rel-overrides.yaml
@@ -5,15 +5,15 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module
-        ref: sprint-35
+        ref: 0.35.1
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_722_OPENJDK11_CR1
+        ref: EAP_723_OPENJDK11_CR2
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_722_CR1
+        ref: EAP_723_CR2
 osbs:
   repository:
     name: containers/jboss-eap-7


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3302
Signed-off-by: Roberto Oliveira rguimara@redhat.com