### PR TITLE
[CLOUD-3279] Fix the RHSSO ImageStreamTag in the eap72-sso-s2i template.

### DIFF
--- a/templates/eap72-sso-s2i.json
+++ b/templates/eap72-sso-s2i.json
@@ -484,7 +484,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "redhat-sso73-openshift:1.1"
+                                "name": "redhat-sso73-openshift:1.0"
                             },
                             "paths": [
                                 {


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3279

The RHSSO image stream version was also bumped to 1.1 by mistake when moving the EAP image stream to 1.1.