### PR TITLE
[CLOUD-3300] Fix RHSSO and EAP image stream tags in the eap72-openjdk…

### DIFF
--- a/templates/eap72-openjdk11-sso-s2i.json
+++ b/templates/eap72-openjdk11-sso-s2i.json
@@ -491,7 +491,7 @@
                             "from": {
                                 "kind": "ImageStreamTag",
                                 "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                                "name": "${EAP_IMAGE_NAME}"
+                                "name": "redhat-sso73-openshift:1.0"
                             },
                             "paths": [
                                 {
@@ -510,7 +510,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap72-openshift:1.1"
+                            "name": "${EAP_IMAGE_NAME}"
                         },
                         "env": [
                             {


### PR DESCRIPTION
…11-sso-s2i template.

https://issues.jboss.org/browse/CLOUD-3300

We're missing CLOUD-3300 in this branch

Signed-off-by: Peter Mačkay <pmackay@redhat.com>