### PR TITLE
[CLOUD-3400] module cleanup, depend on latest eap-cd-env

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -53,7 +53,7 @@ modules:
           - name: jboss.container.maven.35.bash
             version: "3.5"
           - name: jboss.container.eap.cd
-            version: "18.0"
+            version: "latest"
           # This one indirectly installs common logging by creating a link to $BIN_HOME/bin/launch
           # so must be after jboss.container.eap.cd
           - name: jboss.container.maven.default.bash


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/CLOUD-3400
Signed-off-by: jdenise@redhat.com
Depends on latest module.