### PR TITLE
Fix for CLOUD-3408, Allow to build image in osbs

### DIFF
--- a/dev-osbs-overrides.yaml
+++ b/dev-osbs-overrides.yaml
@@ -1,0 +1,37 @@
+schema_version: 1
+
+name: "jboss-eap-7-tech-preview/eap-cd-openshift-rhel8"
+version: "18.0"
+
+modules:
+      repositories:
+          - name: cct_module
+            git:
+                  url: https://github.com/jboss-openshift/cct_module.git
+                  ref: master
+          - name: jboss-eap-modules
+            git:
+                  url: https://github.com/jboss-container-images/jboss-eap-modules.git
+                  ref: master
+          - name: jboss-eap-7-image
+            git:
+                  url: https://github.com/jboss-container-images/jboss-eap-7-image.git
+                  ref: eap-cd-dev
+          - name: wildfly-cekit-modules
+            git:
+                  url: https://github.com/wildfly/wildfly-cekit-modules.git
+                  ref: master
+            
+      install:
+          - name: jboss.container.eap.galleon.build-settings
+            version: "osbs"
+artifacts:
+  - name: maven-repo
+    target: maven-repo.zip
+    md5: a671c558147e426816fa6f7acdef3f51
+
+osbs:
+      repository:
+            name: containers/jboss-eap-7-tech-preview
+            branch: jb-eap-cd-openshift-dev-rhel-8
+

--- a/image.yaml
+++ b/image.yaml
@@ -60,6 +60,8 @@ modules:
           - name: dynamic-resources
           - name: jboss.container.eap.s2i.galleon
           - name: jboss.container.eap.galleon
+          - name: jboss.container.eap.galleon.build-settings
+            version: "public"
           - name: jboss.container.eap.openshift.modules
           - name: os-eap-activemq-rar
             version: "1.1"


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3408
Signed-off-by: jdenise@redhat.com
- New module to set proper settings at image build time.
- dev-osbs-overrides.yaml to build in osbs