### PR TITLE
Fix for CLOUD-3429, EAP Runtime image must contain SSO_FORCE_LEGACY_SECURITY

### DIFF
--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -34,6 +34,8 @@ envs:
       value: "eapadmin"
     - name: MICROPROFILE_CONFIG_DIR_ORDINAL
       value: "500"
+    - name: SSO_FORCE_LEGACY_SECURITY
+      value: "true"
 ports:
     - value: 8443
     - value: 8080


### PR DESCRIPTION
Issue:https://issues.jboss.org/browse/CLOUD-3429
Signed-off-by: jdenise@redhat.com

Set the SSO_FORCE_LEGACY_SECURITY=true in the runtime image.