### PR TITLE
Fix for CLOUD-3453, Remove cd specific module from jboss-eap-modules

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -52,8 +52,9 @@ modules:
             version: "11"
           - name: jboss.container.maven.35.bash
             version: "3.5"
-          - name: jboss.container.eap.cd
-            version: "latest"
+          - name: eap-cd-env-latest
+          - name: jboss.container.eap.setup
+          - name: eap-install-cleanup
           # This one indirectly installs common logging by creating a link to $BIN_HOME/bin/launch
           # so must be after jboss.container.eap.cd
           - name: jboss.container.maven.default.bash


### PR DESCRIPTION
Signed-off-by: jdenise@redhat.com
https://issues.jboss.org/browse/CLOUD-3453

Remove jboss.container.eap.cd:latest module.
