### PR TITLE
CLOUD-3458 Typos and corrections in README.adoc files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ You should have the 'oc' tools available and be logged in to your OpenShift inst
 For example, for OpenShift Online, see: https://docs.openshift.com/online/cli_reference/get_started_cli.html
 [source, bash]
 ----
-for resource in eap72-opendjk11-image-stream.json \
+for resource in eap72-openjdk11-image-stream.json \
   eap72-openjdk11-amq-persistent-s2i.json \
   eap72-openjdk11-amq-s2i.json \
   eap72-openjdk11-basic-s2i.json \
@@ -33,13 +33,13 @@ To update an to the most recent image:
 
 [source, bash]
 ----
-oc import-image jboss-eap72-openjdk11-rhel8-openshift:1.1
+oc import-image jboss-eap72-openjdk11-openshift-rhel8:1.1
 ----
 
 Optionally include namespace to the import:
 [source, bash]
 ----
-oc -n myproject import-image jboss-eap72-openjdk11-rhel8-openshift:1.1
+oc -n myproject import-image jboss-eap72-openjdk11-openshift-rhel8:1.1
 ----
 
 #### Creating New Applications With Templates
@@ -47,13 +47,13 @@ Example:
 
 [source, bash]
 ----
-oc -n myproject new-app eap72-openjdk11-basic-s2i -p APPLICATION_NAME=eap72-basic-app
+oc -n myproject new-app eap72-openjdk11-basic-s2i -p APPLICATION_NAME=eap72-basic-app -p IMAGE_STREAM_NAMESPACE=myproject
 ----
 
-or, if a namespace was used with `-n` above:
+or, if templates were imported into the "openshift" namespace above, the IMAGE_STREAM_NAMESPACE parameter can be omitted:
 [source, bash]
 ----
-oc -n myproject new-app eap72-openjdk11-basic-s2i -p APPLICATION_NAME=eap72-basic-app -p IMAGE_STREAM_NAMESPACE=myproject
+oc -n myproject new-app eap72-openjdk11-basic-s2i -p APPLICATION_NAME=eap72-basic-app
 ----
 
 For more information on application creation and deployment see: https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html/red_hat_jboss_enterprise_application_platform_for_openshift/build_run_java_app_s2i#deploy_eap_s2i


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-3458

When creating new app with

```
oc -n myproject new-app eap72-openjdk11-basic-s2i -p APPLICATION_NAME=eap72-basic-app
```

the image stream would be looked up in "openshift" namespace. So if a user has imported templates without "-n openshift", he should add "-p IMAGE_STREAM_NAMESPACE=myproject" to the new-app command. Otherwise the imagestream will not be found and the app build will not be triggered.

Also there's wrong image name in import-image command, and typo in the "eap72-openjdk11-image-stream.json" file name in the first command.

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
