### PR TITLE
[CLOUD-3466] Add com.sun.crypto.provider to JBOSS_MODULES_SYSTEM_PKGS

### DIFF
--- a/runtime-image/jdk8-overrides.yaml
+++ b/runtime-image/jdk8-overrides.yaml
@@ -6,7 +6,11 @@ version: "7.3.0"
 labels:
     - name: "com.redhat.component"
       value: "jboss-eap-7-eap73-openjdk8-runtime-openshift-rhel8-container"
-
+envs:
+    # env var set by modules in the builder image context, duplicating them here.
+    # CLOUD-3466 - add com.sun.crypto.provider for JDK8
+    - name: JBOSS_MODULES_SYSTEM_PKGS
+      value: "org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider"
 modules:
       repositories:
           - name: cct_module


### PR DESCRIPTION
Only the JDK 8 runtime image requires to add this module to the
system packages.

JIRA: https://issues.redhat.com/browse/CLOUD-3466

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>
