### PR TITLE
Fix for CLOUD-3482, Prometheus can't be enabled when using runtime image

### DIFF
--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -56,6 +56,7 @@ modules:
             version: "11"
           - name: dynamic-resources
           - name: jboss.container.jolokia.bash
+          - name: jboss.container.util.logging.bash
           - name: jboss.container.eap.prometheus.runtime
           - name: os-eap-txnrecovery.run
             version: 'python3'


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3482

Include logging module in runtime image, needed by prometheus.