### PR TITLE
Fix for CLOUD-3505, Provisioned server is not deleted once installed

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -44,7 +44,7 @@ modules:
           - name: wildfly-cekit-modules
             git:
                   url: https://github.com/wildfly/wildfly-cekit-modules.git
-                  ref: 0.18.2
+                  ref: 0.18.3
       install:
           - name: jboss.container.openjdk.jdk
             version: "11"


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3505
Upgrade wildfly-cekit-modules dependency 