### PR TITLE
Adding parameter of S2I_IMAGE_SOURCE_MOUNTS to basic-s2i.json template

### DIFF
--- a/templates/eap-cd-basic-s2i.json
+++ b/templates/eap-cd-basic-s2i.json
@@ -143,6 +143,12 @@
             "required": false
         },
         {
+            "description": "Comma separated list of relative paths in source directory which should be included in the image.",
+            "name": "S2I_IMAGE_SOURCE_MOUNTS",
+            "value": "",
+            "required": false
+        },
+        {
             "description": "Container memory limit",
             "name": "MEMORY_LIMIT",
             "value": "1Gi",
@@ -285,6 +291,10 @@
                             {
                                 "name": "ARTIFACT_DIR",
                                 "value": "${ARTIFACT_DIR}"
+                            },
+                            {
+                                "name": "S2I_IMAGE_SOURCE_MOUNTS",
+                                "value": "${S2I_IMAGE_SOURCE_MOUNTS}"
                             }
                         ],
                         "forcePull": true,


### PR DESCRIPTION
Hi @luck3y ,

I would need to enhance the `eap-cd-basic-s2i.json` template with possibility to define extension directory of WFLY. That's the variable `S2I_IMAGE_SOURCE_MOUNTS`
https://github.com/jboss-openshift/cct_module/blob/master/jboss/container/s2i/core/api/README.adoc#environment-variables

I need to run `postconfigure.sh` script for scripts copied to the `extensions` directory by the `install.sh` script placed under the defined `S2I_IMAGE_SOURCE_MOUNTS`.

I need to update the `eap-cd-basic-s2i.json` as it's templated used in JBoss EAP quickstart testing.

Would be possible to merge this change? Something more needed? Some other way how to proceed with the requirements?

Thanks a lot for hints.
Ondra