### PR TITLE
Fix for CLOUD-3508, galleon module refactoring to handle WF galleon feature-packs

### DIFF
--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -25,7 +25,7 @@ modules:
 artifacts:
   - name: maven-repo
     target: maven-repo.zip
-    md5: 4b9635a42d81f49d73187b83c6626ac1
+    md5: fbfe752d71999fb75dcba68af2e523db
 
 osbs:
       repository:

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -8,7 +8,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: master
+                  ref: 0.39.0
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
@@ -25,7 +25,7 @@ modules:
 artifacts:
   - name: maven-repo
     target: maven-repo.zip
-    md5: fbfe752d71999fb75dcba68af2e523db
+    md5: 95cfb9189c0748c5e25191aaffe1aeac
 
 osbs:
       repository:

--- a/image.yaml
+++ b/image.yaml
@@ -52,7 +52,8 @@ modules:
             version: "11"
           - name: jboss.container.maven.35.bash
             version: "3.5"
-          - name: eap-cd-env-latest
+          # Install env variables and galleon specifics for cd
+          - name: eap-cd-galleon-latest
           - name: jboss.container.eap.setup
           - name: eap-install-cleanup
           # This one indirectly installs common logging by creating a link to $BIN_HOME/bin/launch
@@ -61,6 +62,7 @@ modules:
           - name: dynamic-resources
           - name: jboss.container.eap.s2i.galleon
           - name: jboss.container.eap.galleon
+          - name: jboss.container.eap.galleon.config.ee
           - name: jboss.container.eap.galleon.build-settings
             version: "public"
           - name: jboss.container.eap.openshift.modules

--- a/image.yaml
+++ b/image.yaml
@@ -58,7 +58,6 @@ modules:
           - name: eap-install-cleanup
           # This one indirectly installs common logging by creating a link to $BIN_HOME/bin/launch
           - name: jboss.container.maven.default.bash
-            version: "1!3.5"
           - name: dynamic-resources
           - name: jboss.container.eap.s2i.galleon
           - name: jboss.container.eap.galleon


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3508

Related PR:
https://github.com/jboss-container-images/jboss-eap-7-image/pull/178
https://github.com/jboss-container-images/jboss-eap-modules/pull/183

* New MD5 for new maven-repo.zip (built from CD19 branch)
* New cekit modules to depend on in order to setup CD server and default config