### PR TITLE
[CLOUD-3510] Update overrides files to EAP 7.2.7-1

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -13,7 +13,7 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP_727_CR3
+                  ref: EAP_727_1
 osbs:
       repository:
             name: containers/jboss-eap-7


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3510

Add standalone tag into RHEL 7 cp-overrides file to build a one-off patch OpenShift (RHEL7) image

Signed-Off-By: Daniel Kreling <dbkreling@redhat.com>