### PR TITLE
[CLOUD-3511] Update overrides files to EAP 7.2.7-1

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -13,7 +13,7 @@ modules:
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_726_CR1
+        ref: EAP_727_1
 
 osbs:
   configuration:

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -13,7 +13,7 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP_727_CR3
+                  ref: EAP_727_1
 osbs:
   configuration:
     container:

--- a/rel-overrides.yaml
+++ b/rel-overrides.yaml
@@ -13,7 +13,7 @@ modules:
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_726_CR1
+        ref: EAP_727_1
 
 osbs:
   configuration:


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3511

Add standalone tag into RHEL 7 overrides files to build a one-off patch OpenShift (RHEL8) image

Signed-off-by: Daniel Kreling <dkreling@redhat.com>