### PR TITLE
[CLOUD-3539] Override for openj9 builder and runtime images

### DIFF
--- a/content_sets_rhel8.yml
+++ b/content_sets_rhel8.yml
@@ -1,4 +1,7 @@
 x86_64:
   - rhel-8-for-x86_64-baseos-rpms
   - rhel-8-for-x86_64-appstream-rpms
+s390x:
+  - rhel-8-for-s390x-baseos-rpms
+  - rhel-8-for-s390x-appstream-rpms
 

--- a/rel-j9-11-overrides.yaml
+++ b/rel-j9-11-overrides.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+
+name: "jboss-eap-7/eap73-openj9-11-openshift-rhel8"
+description: "The JBoss EAP 7.3 image for OpenJDK 11 with OpenJ9"
+version: "7.3.0"
+
+modules:
+      install:
+          - name: jboss.container.eap.galleon.build-settings
+            version: "osbs"
+          - name: os-eap-python
+            version: '3.6'
+          - name: jboss.container.java.rm-openjdk
+          - name: jboss.container.openjdk.jdk
+            version: "openj9-11"
+
+packages:
+  manager: dnf
+  content_sets_file: content_sets_rhel8.yml
+
+osbs:
+  configuration:
+    container:
+      platforms:
+        only:
+          - s390x
+      compose:
+        pulp_repos: true
+        include_unpublished_pulp_repos: true
+        packages:
+          - java-11-openj9
+          - java-11-openj9-headless
+          - java-11-openj9-devel
+        signing_intent: release
+        inherit: true
+  repository:
+    name: containers/jboss-eap-7
+    branch: jb-eap-7.3-openj9-11-openshift-cp-rhel-8
+

--- a/runtime-image/content_sets_rhel8.yml
+++ b/runtime-image/content_sets_rhel8.yml
@@ -1,4 +1,6 @@
 x86_64:
   - rhel-8-for-x86_64-baseos-rpms
   - rhel-8-for-x86_64-appstream-rpms
-
+s390x:
+  - rhel-8-for-s390x-baseos-rpms
+  - rhel-8-for-s390x-appstream-rpms

--- a/runtime-image/j9-11-overrides.yaml
+++ b/runtime-image/j9-11-overrides.yaml
@@ -1,0 +1,43 @@
+schema_version: 1
+
+name: "jboss-eap-7/eap73-openj9-11-runtime-openshift-rhel8"
+description: "The JBoss EAP 7.3 runtime image for OpenJDK 11 with OpenJ9"
+version: "7.3.0"
+from: "ubi8:8-released"
+
+labels:
+    - name: "com.redhat.component"
+      value: "jboss-eap-7-eap73-openj9-11-runtime-openshift-rhel8-container"
+
+modules:
+      install:
+          - name: os-eap-python
+            version: '3.6'
+          - name: jboss.container.java.rm-openjdk
+          - name: jboss.container.openjdk.jdk
+            version: "openj9-11"
+
+packages:
+      content_sets_file: content_sets_rhel8.yml
+      install:
+          # required by probes (python 3)
+          - python3-requests
+
+osbs:
+  configuration:
+    container:
+      platforms:
+        only:
+          - s390x
+      compose:
+        pulp_repos: true
+        include_unpublished_pulp_repos: true
+        packages:
+          - java-11-openj9
+          - java-11-openj9-headless
+          - java-11-openj9-devel
+        signing_intent: release
+        inherit: true
+  repository:
+    name: containers/jboss-eap-7
+    branch: jb-eap-7.3-openj9-11-runtime-openshift-cp-rhel8


### PR DESCRIPTION
This commit contains changes to the override files for building builder and runtime images on openj9-11-rhel8.

Jira issue at https://issues.redhat.com/browse/CLOUD-3539

Signed-off-by: Lei Zhang <lzhan@redhat.com>

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
