### PR TITLE
[CLOUD-3563] Set correct version of jboss-modules for runtimes

### DIFF
--- a/eap-xp/runtime-image/image.yaml
+++ b/eap-xp/runtime-image/image.yaml
@@ -50,7 +50,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: EAP_731_DEV2
+                  ref: EAP_731_CR2
       install:
           - name: jboss.container.openjdk.jdk
             version: "11"

--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -50,7 +50,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: EAP_731_DEV2
+                  ref: EAP_731_CR2
       install:
           - name: jboss.container.openjdk.jdk
             version: "11"


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3563

Signed-off-by: Daniel Kreling <dkreling@redhat.com>