### PR TITLE
Update to build xp/xp-runtime for openj9-11 and s390x

### DIFF
--- a/eap-xp/content_sets_rhel8.yml
+++ b/eap-xp/content_sets_rhel8.yml
@@ -1,4 +1,7 @@
 x86_64:
   - rhel-8-for-x86_64-baseos-rpms
   - rhel-8-for-x86_64-appstream-rpms
+s390x:
+  - rhel-8-for-s390x-baseos-rpms
+  - rhel-8-for-s390x-appstream-rpms
 

--- a/eap-xp/rel-j9-11-xp-overrides.yaml
+++ b/eap-xp/rel-j9-11-xp-overrides.yaml
@@ -1,0 +1,40 @@
+schema_version: 1
+
+name: "jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8"
+description: "Red Hat JBoss Enterprise Application Platform XP 1.0 OpenShift container image."
+
+labels:
+      - name: "com.redhat.component"
+        value: "jboss-eap-7-xp1-openj9-11-openshift-rhel8-container"
+
+modules:
+      install:
+          - name: jboss.container.eap.galleon.build-settings
+            version: "osbs"
+          - name: os-eap-python
+            version: '3.6'
+          - name: jboss.container.java.rm-openjdk
+          - name: jboss.container.openjdk.jdk             
+            version: "openj9-11"             
+
+packages:
+  manager: dnf
+  content_sets_file: content_sets_rhel8.yml
+
+osbs:
+  configuration:
+    container:
+      platforms:
+        only:
+          - s390x
+      compose:
+        pulp_repos: true
+        packages:
+          - java-11-openj9
+          - java-11-openj9-headless
+          - java-11-openj9-devel
+        signing_intent: release
+        inherit: true
+  repository:
+    name:  containers/jboss-eap-xp-openj9-11-builder
+    branch: jb-eap-7.3-openshift-rhel-8

--- a/eap-xp/runtime-image/content_sets_rhel8.yml
+++ b/eap-xp/runtime-image/content_sets_rhel8.yml
@@ -1,4 +1,6 @@
 x86_64:
   - rhel-8-for-x86_64-baseos-rpms
   - rhel-8-for-x86_64-appstream-rpms
-
+s390x:
+  - rhel-8-for-s390x-baseos-rpms
+  - rhel-8-for-s390x-appstream-rpms

--- a/eap-xp/runtime-image/rel-j9-11-xp-overrides.yaml
+++ b/eap-xp/runtime-image/rel-j9-11-xp-overrides.yaml
@@ -1,0 +1,41 @@
+schema_version: 1
+
+name: "jboss-eap-7/eap-xp1-openj9-11-runtime-openshift-rhel8"
+description: "Red Hat JBoss Enterprise Application Platform XP 1.0 OpenShift runtime image with Openj9-11"
+
+labels:
+      - name: "com.redhat.component"
+        value: "jboss-eap-7-xp1-openj9-11-runtime-openshift-rhel8-container"
+modules:
+      install:
+          - name: os-eap-python
+            version: '3.6'
+          - name: jboss.container.openjdk.jdk
+            version: "openj9-11"
+
+
+
+packages:
+     content_sets_file: content_sets_rhel8.yml
+     install:
+         # required by probes (python 3)
+         - python3-requests
+
+osbs:
+  configuration:
+    container:
+      platforms:
+        only:
+          - s390x
+      compose:
+        pulp_repos: true
+        packages:
+          - java-11-openj9
+          - java-11-openj9-headless
+          - java-11-openj9-devel
+        signing_intent: release
+        inherit: true
+
+  repository:
+    name:  containers/jboss-eap-xp-openj9-11-runtime
+    branch: jb-eap-7.3-openshift-rhel-8     


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-3673
Signed-off-by: Sam Ding  shding@redhat.com
 Added for  building eap-xp/xp-runtime for openj9-11/s390x. 