### PR TITLE
[CLOUD-3803] Include OPENj9 RPMS of z and p to avoid CVP error

### DIFF
--- a/content_sets_rhel8.yml
+++ b/content_sets_rhel8.yml
@@ -4,6 +4,8 @@ x86_64:
 s390x:
   - rhel-8-for-s390x-baseos-rpms
   - rhel-8-for-s390x-appstream-rpms
+  - openj9-1-for-rhel-8-s390x-rpms
 ppc64le:
   - rhel-8-for-ppc64le-baseos-rpms
   - rhel-8-for-ppc64le-appstream-rpms
+  - openj9-1-for-rhel-8-ppc64le-rpms

--- a/eap-xp/content_sets_rhel8.yml
+++ b/eap-xp/content_sets_rhel8.yml
@@ -4,6 +4,8 @@ x86_64:
 s390x:
   - rhel-8-for-s390x-baseos-rpms
   - rhel-8-for-s390x-appstream-rpms
+  - openj9-1-for-rhel-8-s390x-rpms
 ppc64le:
   - rhel-8-for-ppc64le-baseos-rpms
   - rhel-8-for-ppc64le-appstream-rpms
+  - openj9-1-for-rhel-8-ppc64le-rpms

--- a/eap-xp/runtime-image/content_sets_rhel8.yml
+++ b/eap-xp/runtime-image/content_sets_rhel8.yml
@@ -4,6 +4,8 @@ x86_64:
 s390x:
   - rhel-8-for-s390x-baseos-rpms
   - rhel-8-for-s390x-appstream-rpms
+  - openj9-1-for-rhel-8-s390x-rpms
 ppc64le:
   - rhel-8-for-ppc64le-baseos-rpms
   - rhel-8-for-ppc64le-appstream-rpms
+  - openj9-1-for-rhel-8-ppc64le-rpms

--- a/runtime-image/content_sets_rhel8.yml
+++ b/runtime-image/content_sets_rhel8.yml
@@ -4,6 +4,8 @@ x86_64:
 s390x:
   - rhel-8-for-s390x-baseos-rpms
   - rhel-8-for-s390x-appstream-rpms
+  - openj9-1-for-rhel-8-s390x-rpms
 ppc64le:
   - rhel-8-for-ppc64le-baseos-rpms
   - rhel-8-for-ppc64le-appstream-rpms
+  - openj9-1-for-rhel-8-ppc64le-rpms


### PR DESCRIPTION
Signed-off-by: Sam Ding <shding@redhat.com>
https://issues.redhat.com/browse/CLOUD-3803

Include openj9 rpm of s390x & ppc64le  into `content_sets_rhel8.yml` to avoid image  CVP  `content_set_check`  check failure.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
