### PR TITLE
[CLOUD-3841] Update image-builder to include one-off fixes for OpenSSL and FasterXML

### DIFF
--- a/eap-xp/image.yaml
+++ b/eap-xp/image.yaml
@@ -120,7 +120,7 @@ modules:
 artifacts:
   - name: maven-repo
     target: maven-repo.zip
-    md5: 2cfe2c1053c433c9594c8c9639f83fe9
+    md5: 1f3c35c791e60f7f620bc90d36f2fa3f
 
 run:
       user: 185

--- a/image.yaml
+++ b/image.yaml
@@ -120,7 +120,7 @@ modules:
 artifacts:
   - name: maven-repo
     target: maven-repo.zip
-    md5: d49aeeb95145eaf501676406610f1200
+    md5: c41e45b8dbee5116024be5116d223bdc
 
 run:
       user: 185


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3841

One-off fixes for Openssl and FasterXML Jackson databind were included in
a new image-builder and a respin is necessary to consume those fixes.

Signed-off-by: Daniel Kreling <dkreling@gmail.com>