### PR TITLE
[CLOUD-3848] replace base image to registry.redhat.io/rhel7/rhel:latest

### DIFF
--- a/eap-xp/rel-jdk8-xp-overrides.yaml
+++ b/eap-xp/rel-jdk8-xp-overrides.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: "jboss-eap-7/eap-xp1-openjdk8-openshift-rhel7"
-from: "ubi7:7-released"
+from: "registry.redhat.io/rhel7/rhel:latest"
 
 labels:
     - name: "com.redhat.component"

--- a/eap-xp/rel-jdk8-xp-overrides.yaml
+++ b/eap-xp/rel-jdk8-xp-overrides.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: "jboss-eap-7/eap-xp1-openjdk8-openshift-rhel7"
-from: "registry.redhat.io/rhel7/rhel:latest"
+from: "registry.redhat.io/ubi7/ubi:latest"
 
 labels:
     - name: "com.redhat.component"

--- a/eap-xp/runtime-image/rel-jdk8-xp-overrides.yaml
+++ b/eap-xp/runtime-image/rel-jdk8-xp-overrides.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "jboss-eap-7/eap-xp1-openjdk8-runtime-openshift-rhel7"
 description: "Red Hat JBoss Enterprise Application Platform XP 1.0 OpenShift runtime image with OpenJDK 8"
-from: "ubi7:7-released"
+from: "registry.redhat.io/rhel7/rhel:latest"
 
 labels:
     - name: "com.redhat.component"

--- a/eap-xp/runtime-image/rel-jdk8-xp-overrides.yaml
+++ b/eap-xp/runtime-image/rel-jdk8-xp-overrides.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "jboss-eap-7/eap-xp1-openjdk8-runtime-openshift-rhel7"
 description: "Red Hat JBoss Enterprise Application Platform XP 1.0 OpenShift runtime image with OpenJDK 8"
-from: "registry.redhat.io/rhel7/rhel:latest"
+from: "registry.redhat.io/ubi7/ubi:latest"
 
 labels:
     - name: "com.redhat.component"

--- a/rel-jdk8-overrides.yaml
+++ b/rel-jdk8-overrides.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: "jboss-eap-7/eap73-openjdk8-openshift-rhel7"
-from: "registry.redhat.io/rhel7/rhel:latest"
+from: "registry.redhat.io/ubi7/ubi:latest"
 
 labels:
     - name: "com.redhat.component"

--- a/rel-jdk8-overrides.yaml
+++ b/rel-jdk8-overrides.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: "jboss-eap-7/eap73-openjdk8-openshift-rhel7"
-from: "ubi7:7-released"
+from: "registry.redhat.io/rhel7/rhel:latest"
 
 labels:
     - name: "com.redhat.component"

--- a/runtime-image/jdk11-overrides.yaml
+++ b/runtime-image/jdk11-overrides.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "jboss-eap-7/eap73-openjdk11-runtime-openshift-rhel8"
 description: "The JBoss EAP 7.3 openjdk11 runtime image"
-from: "ubi8:8-released"
+from: "registry.redhat.io/ubi8/ubi:latest"
 
 labels:
     - name: "com.redhat.component"

--- a/runtime-image/jdk8-overrides.yaml
+++ b/runtime-image/jdk8-overrides.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "jboss-eap-7/eap73-openjdk8-runtime-openshift-rhel7"
 description: "The JBoss EAP 7.3 openjdk8 runtime image"
-from: "ubi7:7-released"
+from: "registry.redhat.io/rhel7/rhel:latest"
 
 labels:
     - name: "com.redhat.component"

--- a/runtime-image/jdk8-overrides.yaml
+++ b/runtime-image/jdk8-overrides.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "jboss-eap-7/eap73-openjdk8-runtime-openshift-rhel7"
 description: "The JBoss EAP 7.3 openjdk8 runtime image"
-from: "registry.redhat.io/rhel7/rhel:latest"
+from: "registry.redhat.io/ubi7/ubi:latest"
 
 labels:
     - name: "com.redhat.component"


### PR DESCRIPTION
RHEL 7 registries need to be updated, according to docs at
https://docs.engineering.redhat.com/pages/viewpage.action?spaceKey=RHAPPINFRA&title=Container+images+to+inherit+from

Also update runtime-image, rhel8 one that was left behind.

Signed-off-by: Daniel Kreling <dkreling@redhat.com>
