### PR TITLE
[CLOUD-3876] Add com.redhat.deployments-dir label to runtime images

### DIFF
--- a/eap-xp/runtime-image/image.yaml
+++ b/eap-xp/runtime-image/image.yaml
@@ -17,6 +17,8 @@ labels:
       value: "javaee,eap,eap7"
     - name: "maintainer"
       value: "Red Hat"
+    - name: "com.redhat.deployments-dir"
+      value: "/opt/eap/standalone/deployments"
 envs:
     - name: "LAUNCH_JBOSS_IN_BACKGROUND"
       value: "true"

--- a/eap-xp2/runtime-image/image.yaml
+++ b/eap-xp2/runtime-image/image.yaml
@@ -17,6 +17,8 @@ labels:
       value: "javaee,eap,eap7"
     - name: "maintainer"
       value: "Red Hat"
+    - name: "com.redhat.deployments-dir"
+      value: "/opt/eap/standalone/deployments"
 envs:
     - name: "LAUNCH_JBOSS_IN_BACKGROUND"
       value: "true"

--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -17,6 +17,8 @@ labels:
       value: "javaee,eap,eap7"
     - name: "maintainer"
       value: "Red Hat"
+    - name: "com.redhat.deployments-dir"
+      value: "/opt/eap/standalone/deployments"
 envs:
     - name: "LAUNCH_JBOSS_IN_BACKGROUND"
       value: "true"


### PR DESCRIPTION
This label is set on the builder images but was missing from the runtime
images preventing inspection of its value to find where deployments can
be put.

JIRA: https://issues.redhat.com/browse/CLOUD-3876

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>
