### PR TITLE
[CLOUD-3910] Update image builder mvn repo md5 for XP 2.0.0.GA-7.3.5.GA

### DIFF
--- a/eap-xp2/image.yaml
+++ b/eap-xp2/image.yaml
@@ -120,7 +120,7 @@ modules:
 artifacts:
   - name: maven-repo
     target: maven-repo.zip
-    md5: 8d896ac84f48fea44b81fe35e983ef3d
+    md5: d3a9851012a10a54f0c57953affb5540
 
 run:
       user: 185


### PR DESCRIPTION
The image builder maven repository had to be rebuilt because the runtimes BOMs versions
needed to be adjusted.

Issue: https://issues.redhat.com/browse/CLOUD-3910

Signed-off-by: Daniel Kreling <dkreling@redhat.com>