### PR TITLE
[CLOUD-3951] Bump maven module to version 3.6

### DIFF
--- a/dev-jdk8-overrides.yaml
+++ b/dev-jdk8-overrides.yaml
@@ -29,8 +29,8 @@ modules:
       install:
           - name: jboss.container.openjdk.jdk
             version: "8"
-          - name: jboss.container.maven.35.bash
-            version: "3.5scl"
+          - name: jboss.container.maven.36.bash
+            version: "3.6scl"
           - name: os-eap-txnrecovery.run
             version: 'python2'
           - name: os-eap-probes

--- a/eap-xp/image.yaml
+++ b/eap-xp/image.yaml
@@ -48,8 +48,8 @@ modules:
       install:
           - name: jboss.container.openjdk.jdk
             version: "11"
-          - name: jboss.container.maven.35.bash
-            version: "3.5"
+          - name: jboss.container.maven.36.bash
+            version: "3.6"
           - name: eap-xp-10-env
             version: "1.0.5"
           - name: jboss.container.eap.setup

--- a/eap-xp/rel-jdk8-xp-overrides.yaml
+++ b/eap-xp/rel-jdk8-xp-overrides.yaml
@@ -11,8 +11,8 @@ modules:
       install:
           - name: jboss.container.openjdk.jdk
             version: "8"
-          - name: jboss.container.maven.35.bash
-            version: "3.5scl"
+          - name: jboss.container.maven.36.bash
+            version: "3.6scl"
           - name: jboss.container.eap.galleon.build-settings
             version: "osbs"
           - name: os-eap-txnrecovery.run

--- a/eap-xp2/image.yaml
+++ b/eap-xp2/image.yaml
@@ -48,8 +48,8 @@ modules:
       install:
           - name: jboss.container.openjdk.jdk
             version: "11"
-          - name: jboss.container.maven.35.bash
-            version: "3.5"
+          - name: jboss.container.maven.36.bash
+            version: "3.6"
           - name: eap-xp-20-env
             version: "1.0.0"
           - name: jboss.container.eap.setup

--- a/eap-xp2/rel-jdk8-xp-overrides.yaml
+++ b/eap-xp2/rel-jdk8-xp-overrides.yaml
@@ -11,8 +11,8 @@ modules:
       install:
           - name: jboss.container.openjdk.jdk
             version: "8"
-          - name: jboss.container.maven.35.bash
-            version: "3.5scl"
+          - name: jboss.container.maven.36.bash
+            version: "3.6scl"
           - name: jboss.container.eap.galleon.build-settings
             version: "osbs"
           - name: os-eap-txnrecovery.run

--- a/image.yaml
+++ b/image.yaml
@@ -32,7 +32,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.39.1
+                  ref: 0.39.2
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
@@ -48,8 +48,8 @@ modules:
       install:
           - name: jboss.container.openjdk.jdk
             version: "11"
-          - name: jboss.container.maven.35.bash
-            version: "3.5"
+          - name: jboss.container.maven.36.bash
+            version: "3.6"
           - name: eap-73-env
             version: "7.3.6"
           - name: jboss.container.eap.setup

--- a/rel-jdk8-overrides.yaml
+++ b/rel-jdk8-overrides.yaml
@@ -11,8 +11,8 @@ modules:
       install:
           - name: jboss.container.openjdk.jdk
             version: "8"
-          - name: jboss.container.maven.35.bash
-            version: "3.5scl"
+          - name: jboss.container.maven.36.bash
+            version: "3.6scl"
           - name: jboss.container.eap.galleon.build-settings
             version: "osbs"
           - name: os-eap-txnrecovery.run


### PR DESCRIPTION
Maven 3.5 has reached EOL. Bump it to version 3.6.

Signed-off-by: Daniel Kreling <dkreling@redhat.com>
