### PR TITLE
[CLOUD-3951] Bump remaining references to cct_modules version 0.39.2

### DIFF
--- a/eap-xp/image.yaml
+++ b/eap-xp/image.yaml
@@ -32,7 +32,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.39.1
+                  ref: 0.39.2
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/eap-xp/runtime-image/image.yaml
+++ b/eap-xp/runtime-image/image.yaml
@@ -48,7 +48,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.39.1
+                  ref: 0.39.2
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/eap-xp2/image.yaml
+++ b/eap-xp2/image.yaml
@@ -32,7 +32,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.39.1
+                  ref: 0.39.2
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/eap-xp2/runtime-image/image.yaml
+++ b/eap-xp2/runtime-image/image.yaml
@@ -48,7 +48,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.39.1
+                  ref: 0.39.2
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -48,7 +48,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.39.1
+                  ref: 0.39.2
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3951

Version 0.39.2 introduces support for maven 3.6.

Signed-off-by: Daniel Kreling <dkreling@redhat.com>