### PR TITLE
[JBEAP-20690] URI working with RH-SSO 7.4.2 is rejected in 7.4.3 (jdk11)

### DIFF
--- a/templates/eap73-openjdk11-sso-s2i.json
+++ b/templates/eap73-openjdk11-sso-s2i.json
@@ -50,6 +50,13 @@
             "required": true
         },
         {
+            "displayName": "Custom http Route Hostname",
+            "description": "Custom hostname for http service route. Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix>",
+            "name": "HOSTNAME_HTTP",
+            "value": "",
+            "required": false
+        },
+        {
             "displayName": "Custom https Route Hostname",
             "description": "Hostname for https service route (e.g. secure-eap-app-myproject.example.com).  Required for SSO-enabled applications.  This is added to the white list of redirects in the SSO server.",
             "name": "HOSTNAME_HTTPS",


### PR DESCRIPTION
https://issues.redhat.com/browse/JBEAP-20690

We missed the opendjk 11 template when backporting the fix to 7.3.x
