### PR TITLE
CLOUD-4006 - Runtime image incorrectly includes org.jboss.logmanager in JBOSS_MODULES_SYSTEM_PKGS

### DIFF
--- a/eap-xp3/runtime-image/image.yaml
+++ b/eap-xp3/runtime-image/image.yaml
@@ -29,7 +29,7 @@ envs:
       value: "/opt/eap"
     # env var set by modules in the builder image context, duplicating them here.
     - name: JBOSS_MODULES_SYSTEM_PKGS
-      value: "org.jboss.logmanager,jdk.nashorn.api"
+      value: "jdk.nashorn.api"
     - name: DEFAULT_ADMIN_USERNAME
       value: "eapadmin"
     - name: MICROPROFILE_CONFIG_DIR_ORDINAL


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-4006
Signed-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
