### PR TITLE
[CLOUD-4007] EAP XP 3.0 - Removed OpenJ9 packages to install using content_set repo

### DIFF
--- a/eap-xp3/rel-j9-11-xp-overrides.yaml
+++ b/eap-xp3/rel-j9-11-xp-overrides.yaml
@@ -30,12 +30,7 @@ osbs:
           - ppc64le
       compose:
         pulp_repos: true
-        packages:
-          - java-11-openj9
-          - java-11-openj9-headless
-          - java-11-openj9-devel
         signing_intent: release
-        inherit: true
   repository:
     name:  containers/jboss-eap-xp3-openj9-11-builder
     branch: jb-eap-xp3-rhel-8


### PR DESCRIPTION
Removing openj9 packages from osbs compose to install from content_set repo instead of odcs.
JIRA issue:
https://issues.redhat.com/browse/CLOUD-4007

Signed-off-by: Rafiur Rashid rrashid@redhat.com

- [X] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
