### PR TITLE
[CLOUD-4024] EAP XP 3.0 adding missing modules for openj9

### DIFF
--- a/eap-xp3/rel-j9-11-xp-overrides.yaml
+++ b/eap-xp3/rel-j9-11-xp-overrides.yaml
@@ -16,6 +16,12 @@ modules:
           - name: jboss.container.openjdk.jdk
             version: "openj9-11"
           - name: jboss.container.java.singleton-jdk
+          - name: jboss.container.maven.module
+            version: "3.6"
+          - name: jboss.container.jolokia
+            version: '7'
+          - name: jboss.container.prometheus
+            version: '7'
 
 packages:
   manager: dnf


### PR DESCRIPTION
Adding 3 missing modules - Jolokia, maven & prometheus.
JIRA issue:
https://issues.redhat.com/browse/CLOUD-4024

Signed-off-by: Rafiur Rashid rrashid@redhat.com

- [X] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
