### PR TITLE
[CLOUD-4048] EAP 7.4.2 One-off respin

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -42,7 +42,7 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP_742_CR1
+                  ref: EAP_742_CR1_2
           - name: wildfly-cekit-modules
             git:
                   url: https://github.com/wildfly/wildfly-cekit-modules.git
@@ -122,7 +122,7 @@ modules:
 artifacts:
   - name: maven-repo
     target: maven-repo.zip
-    md5: 115acd5c7fbcaea84f843c593e850515
+    md5: 0b8ebe602de25bdeebece48e0f00d1ab
 
 run:
       user: 185


### PR DESCRIPTION
JBEAP-22674 files an issue with JMS integration with the wildfly-wildfly
server version 00002 and a new version 00003 had to be rebuilt with the fix.
A new image-builder-maven-repository has also been re-generated.

Issue: https://issues.redhat.com/browse/CLOUD-4048
Signed-off-by: Daniel Kreling <dkreling@redhat.com>
