### PR TITLE
revert to 7.4.2.GA-redhat-00002

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -42,7 +42,7 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  ref: EAP_742_CR1_2
+                  ref: EAP_742_CR1
           - name: wildfly-cekit-modules
             git:
                   url: https://github.com/wildfly/wildfly-cekit-modules.git


### PR DESCRIPTION
Roll back the base image (standalone) tag

Issue: https://issues.redhat.com/browse/CLOUD-4048
Signed-off-by: Daniel Kreling <dkreling@redhat.com>