### PR TITLE
[CLOUD-4111] Update jboss-eap-modules in runtime image

### DIFF
--- a/eap-xp3/runtime-image/image.yaml
+++ b/eap-xp3/runtime-image/image.yaml
@@ -50,7 +50,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: EAP_XP3_CR2
+                  ref: EAP_XP3_745_CR1
       install:
           - name: jboss.container.openjdk.jdk
             version: "11"


### PR DESCRIPTION
Issue: [CLOUD-4111](https://issues.redhat.com/browse/CLOUD-4111)
