### PR TITLE
CLOUD-4120 - add aarch64/arm to arches built for JDK 17 image.

### DIFF
--- a/jdk17-image/content_sets_rhel8.yml
+++ b/jdk17-image/content_sets_rhel8.yml
@@ -1,0 +1,12 @@
+x86_64:
+  - rhel-8-for-x86_64-baseos-rpms
+  - rhel-8-for-x86_64-appstream-rpms
+s390x:
+  - rhel-8-for-s390x-baseos-rpms
+  - rhel-8-for-s390x-appstream-rpms
+ppc64le:
+  - rhel-8-for-ppc64le-baseos-rpms
+  - rhel-8-for-ppc64le-appstream-rpms
+aarch64:
+  - rhel-8-for-aarch64-baseos-rpms
+  - rhel-8-for-aarch64-appstream-rpms

--- a/jdk17-image/image.yaml
+++ b/jdk17-image/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "jboss-eap-7-tech-preview/eap74-openjdk17-openshift-rhel8"
 description: "Red Hat JBoss Enterprise Application Platform 7.4 OpenShift container image."
-version: "7.4.5"
+version: "7.4.6"
 from: "registry.redhat.io/ubi8/ubi:latest"
 labels:
     - name: "com.redhat.component"
@@ -44,7 +44,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: EAP_746_CR2_JDK17
+                  ref: EAP_746_CR1_JDK17
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
@@ -142,7 +142,7 @@ run:
 
 packages:
   manager: dnf
-  content_sets_file: ../content_sets_rhel8.yml
+  content_sets_file: content_sets_rhel8.yml
 
 osbs:
   configuration:
@@ -152,6 +152,7 @@ osbs:
           - x86_64
           - s390x
           - ppc64le
+          - aarch64
       compose:
         pulp_repos: true
         signing_intent: release

--- a/runtime-image/content_sets_rhel8-all.yml
+++ b/runtime-image/content_sets_rhel8-all.yml
@@ -1,0 +1,12 @@
+x86_64:
+  - rhel-8-for-x86_64-baseos-rpms
+  - rhel-8-for-x86_64-appstream-rpms
+s390x:
+  - rhel-8-for-s390x-baseos-rpms
+  - rhel-8-for-s390x-appstream-rpms
+ppc64le:
+  - rhel-8-for-ppc64le-baseos-rpms
+  - rhel-8-for-ppc64le-appstream-rpms
+aarch64:
+  - rhel-8-for-aarch64-baseos-rpms
+  - rhel-8-for-aarch64-appstream-rpms

--- a/runtime-image/jdk17-overrides.yaml
+++ b/runtime-image/jdk17-overrides.yaml
@@ -32,7 +32,7 @@ modules:
             version: '7'
 
 packages:
-      content_sets_file: content_sets_rhel8.yml
+      content_sets_file: content_sets_rhel8-all.yml
       install:
           # required by probes (python 3)
           - python3-requests
@@ -45,6 +45,7 @@ osbs:
           - x86_64
           - s390x
           - ppc64le
+          - aarch64
       compose:
         pulp_repos: true
         signing_intent: release


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-4120
Signed-off-by: Ken Wills <kwills@redhat.com>