### PR TITLE
[CLOUD-4169] Update wildfly-cekit-modules to 0.23.9

### DIFF
--- a/eap-xp4/image.yaml
+++ b/eap-xp4/image.yaml
@@ -44,7 +44,7 @@ modules:
           - name: wildfly-cekit-modules
             git:
                   url: https://github.com/wildfly/wildfly-cekit-modules.git
-                  ref: 0.23.8
+                  ref: 0.23.9
       install:
           - name: jboss.container.openjdk.jdk
             version: "11"


### PR DESCRIPTION
Issue: [CLOUD-4169](https://issues.redhat.com/browse/CLOUD-4169)