### PR TITLE
Install tzdata-java

### DIFF
--- a/rel-jdk11-overrides.yaml
+++ b/rel-jdk11-overrides.yaml
@@ -3,6 +3,7 @@ schema_version: 1
 name: "jboss-eap-7/eap74-openjdk11-openshift-rhel8"
 modules:
       install:
+          - name: jboss.container.eap.tzdata-java      
           - name: jboss.container.eap.galleon.build-settings
             version: "osbs"
           - name: jboss.container.maven.module


### PR DESCRIPTION
Issue: https://access.redhat.com/solutions/7025428

tzdata-java is not part of JDK 11.0.20

Signed-off-by: Ruben Dario Novelli [rnovelli@redhat.com](mailto:rnovelli@redhat.com)
