### PR TITLE
Move tzdata-java install to image file

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -51,6 +51,7 @@ modules:
           - name: jboss.container.eap.jdk-cert
           - name: jboss.container.openjdk.jdk
             version: "11"
+          - name: jboss.container.eap.tzdata-java            
           - name: jboss.container.maven
             version: "8.2.3.6"
           - name: eap-74-galleon-latest

--- a/rel-jdk11-overrides.yaml
+++ b/rel-jdk11-overrides.yaml
@@ -3,7 +3,6 @@ schema_version: 1
 name: "jboss-eap-7/eap74-openjdk11-openshift-rhel8"
 modules:
       install:
-          - name: jboss.container.eap.tzdata-java      
           - name: jboss.container.eap.galleon.build-settings
             version: "osbs"
           - name: jboss.container.maven.module


### PR DESCRIPTION
Issue: https://access.redhat.com/solutions/7025428

tzdata-java is not part of JDK 11.0.20

Signed-off-by: Ruben Dario Novelli [rnovelli@redhat.com](mailto:rnovelli@redhat.com)