### PR TITLE
Add jdk-cert manipulation

### DIFF
--- a/eap-xp4-jdk17/image.yaml
+++ b/eap-xp4-jdk17/image.yaml
@@ -54,6 +54,7 @@ modules:
           - name: jdk-modules
             path: ../modules                      
       install:
+          - name: jboss.container.eap.jdk-cert
           - name: jboss.container.openjdk.jdk
             version: "17"
           - name: jboss.container.maven
@@ -137,6 +138,7 @@ modules:
           - name: jboss.container.wildfly.galleon.build-feature-pack
           - name: jboss.container.wildfly.galleon.provision-server
           - name: jboss.container.eap.final-setup
+          - name: jboss.container.eap.jdk-cert-remove
 
 packages:
   manager: dnf


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-4192
Signed-off-by: Ruben Dario Novelli [rnovelli@redhat.com](mailto:rnovelli@redhat.com)

JDK17 needs the internal certificate to talk with the HTTPS maven repository