### PR TITLE
Fix for JBEAP-24017, [7.4.* JDK 17 images] - Missing required KEYCLOAK mechanism

### DIFF
--- a/eap-xp4-jdk17/image.yaml
+++ b/eap-xp4-jdk17/image.yaml
@@ -42,7 +42,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: EAP_XP401_7412_CR1
+                  ref: master
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
@@ -88,7 +88,7 @@ modules:
           - name: jboss.container.java.jvm.bash
             version: "2.0"
           - name: jboss.container.eap.launch
-            version: "1.0-mp-no-sso"
+            version: "1.0-mp"
           - name: jboss.container.wildfly.launch.admin
           - name: jboss.container.wildfly.launch.access-log-valve
           - name: jboss.container.wildfly.launch-config.config
@@ -103,8 +103,7 @@ modules:
           - name: jboss.container.wildfly.launch.os.node-name
           - name: jboss.container.wildfly.launch.tracing
           - name: jboss.container.wildfly.launch.deployment-scanner
-          # No SSO
-          #- name: jboss.container.wildfly.launch.keycloak
+          - name: jboss.container.wildfly.launch.keycloak
           - name: jboss.container.wildfly.launch.https
           - name: jboss.container.wildfly.launch.security-domains
           - name: jboss.container.wildfly.launch.elytron
@@ -112,11 +111,9 @@ modules:
           - name: jboss.container.wildfly.launch.resource-adapters
           - name: jboss.container.wildfly.launch.messaging
           - name: jboss.container.wildfly.launch.statefulset
-          # needs to be before fp-content.keycloak to copy modules used to generate galleon packages
-          # No SSO          
-          #- name: os-eap70-sso
-          # No SSO
-          #- name: jboss.container.wildfly.galleon.fp-content.keycloak
+          # needs to be before fp-content.keycloak to copy modules used to generate galleon packages        
+          - name: os-eap70-sso
+          - name: jboss.container.wildfly.galleon.fp-content.keycloak
           - name: jboss.container.wildfly.galleon.fp-content.jolokia
           - name: jboss.container.wildfly.galleon.fp-content.java
           - name: jboss.container.wildfly.galleon.fp-content.config

--- a/jdk17-image/image.yaml
+++ b/jdk17-image/image.yaml
@@ -44,7 +44,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: EAP_7413_CR1
+                  ref: master
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
@@ -83,7 +83,7 @@ modules:
           - name: jboss.container.java.jvm.bash
             version: "2.0"
           - name: jboss.container.eap.launch
-            version: "1.0-no-sso"
+            version: "1.0"
           - name: jboss.container.wildfly.launch.admin
           - name: jboss.container.wildfly.launch.access-log-valve
           - name: jboss.container.wildfly.launch-config.config
@@ -96,6 +96,7 @@ modules:
           - name: jboss.container.wildfly.launch.logger-category
           - name: jboss.container.wildfly.launch.os.node-name
           - name: jboss.container.wildfly.launch.deployment-scanner
+          - name: jboss.container.wildfly.launch.keycloak
           - name: jboss.container.wildfly.launch.https
           - name: jboss.container.wildfly.launch.security-domains
           - name: jboss.container.wildfly.launch.elytron
@@ -103,6 +104,9 @@ modules:
           - name: jboss.container.wildfly.launch.resource-adapters
           - name: jboss.container.wildfly.launch.messaging
           - name: jboss.container.wildfly.launch.statefulset
+          # needs to be before fp-content.keycloak to copy modules used to generate galleon packages
+          - name: os-eap70-sso
+          - name: jboss.container.wildfly.galleon.fp-content.keycloak
           - name: jboss.container.wildfly.galleon.fp-content.jolokia
           - name: jboss.container.wildfly.galleon.fp-content.java
           - name: jboss.container.wildfly.galleon.fp-content.config


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-24017
 The fix applies to both EAP 7.4.x and XP4 images.
Depends on: https://github.com/jboss-container-images/jboss-eap-modules/pull/280