### PR TITLE
[CLOUD-4210] Update cct_module to 0.45.6

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -34,7 +34,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.45.5
+                  ref: 0.45.6
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/jdk17-image/image.yaml
+++ b/jdk17-image/image.yaml
@@ -40,7 +40,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.45.5
+                  ref: 0.45.6
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -49,7 +49,7 @@ modules:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: 0.45.5
+                  ref: 0.45.6
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-4210
Signed-off-by: Ruben Dario Novelli [rnovelli@redhat.com](mailto:rnovelli@redhat.com)