### PR TITLE
Remove repo

### DIFF
--- a/eap-xp4-jdk17/image.yaml
+++ b/eap-xp4-jdk17/image.yaml
@@ -35,10 +35,6 @@ ports:
     - value: 8443
 modules:
       repositories:
-          - name: openjdk
-            git:
-                  url: https://github.com/jboss-container-images/openjdk
-                  ref: wildfly-container-29.0
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git

--- a/eap-xp4-jdk17/runtime-image/image.yaml
+++ b/eap-xp4-jdk17/runtime-image/image.yaml
@@ -48,10 +48,6 @@ ports:
       expose: false
 modules:
       repositories:
-          - name: openjdk
-            git:
-                  url: https://github.com/jboss-container-images/openjdk
-                  ref: wildfly-container-29.0      
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git

--- a/eap-xp4/image.yaml
+++ b/eap-xp4/image.yaml
@@ -29,10 +29,6 @@ ports:
     - value: 8443
 modules:
       repositories:
-          - name: openjdk
-            git:
-                  url: https://github.com/jboss-container-images/openjdk
-                  ref: wildfly-container-29.0      
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git

--- a/eap-xp4/runtime-image/image.yaml
+++ b/eap-xp4/runtime-image/image.yaml
@@ -41,10 +41,6 @@ ports:
       expose: false
 modules:
       repositories:
-          - name: openjdk
-            git:
-                  url: https://github.com/jboss-container-images/openjdk
-                  ref: wildfly-container-29.0      
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-4245
Signed-off-by: Ruben Dario Novelli [rnovelli@redhat.com](mailto:rnovelli@redhat.com)

Repo is not required module already exists in cct_module/jboss/container/util/pkg-update
