### PR TITLE
Change git ref for jboss-eap-modules

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -38,7 +38,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: master
+                  ref: EAP_7423_CR2_JBEAP_31370
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git

--- a/jdk17-image/image.yaml
+++ b/jdk17-image/image.yaml
@@ -44,7 +44,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: master
+                  ref: EAP_7423_CR2_JBEAP_31370
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git

--- a/runtime-image/image.yaml
+++ b/runtime-image/image.yaml
@@ -53,7 +53,7 @@ modules:
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: master
+                  ref: EAP_7423_CR2_JBEAP_31370
       install:
           - name: jboss.container.util.pkg-update      
           - name: jboss.container.openjdk.jdk


### PR DESCRIPTION
Updated git reference for jboss-eap-modules to EAP_7423_CR2_JBEAP_31370.